### PR TITLE
Improve the cleanup of the liferay body html

### DIFF
--- a/fix_liferay.php
+++ b/fix_liferay.php
@@ -17,15 +17,15 @@ $migration_tool = new UNL_Migration_Tool($baseUrl, $frontierPath, $frontierUser,
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Liferay main content fixer</title>
+  <title>Liferay body fixer</title>
   <link rel="stylesheet" href="style.css">
   <script src="script.js"></script>
 </head>
 <body>
-  <h1>Fix Liferay main content</h1>
+  <h1>Fix Liferay Body HTML</h1>
   <p>This will strip out/replace old lefray DIVs and Content</p>
   <form action="fix_liferay.php" method="post">
-    <label for="content_to_fix">The HTML content to fix</label>
+    <label for="content_to_fix">The HTML body to fix</label>
     <br />
     <textarea id="content_to_fix" name="content" cols="100" rows="15"></textarea>
     <br />

--- a/fix_liferay.php
+++ b/fix_liferay.php
@@ -44,8 +44,12 @@ $migration_tool = new UNL_Migration_Tool($baseUrl, $frontierPath, $frontierUser,
     <br />
     <label for="fixed_html">Fixed HTML</label>
     <br />
-    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo htmlentities($fixed_content, null, 'UTF-8', false) ?></textarea>
-    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo $fixed_content ?></textarea>
+    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo htmlentities($fixed_content, null, 'UTF-8') ?></textarea>
+    <br />
+    <br />
+    <pre>
+<?php echo htmlentities($fixed_content, null, 'UTF-8') ?>
+    </pre>
   <?php endif; ?>
 <!-- page content -->
 </body>

--- a/fix_liferay.php
+++ b/fix_liferay.php
@@ -39,7 +39,7 @@ $migration_tool = new UNL_Migration_Tool($baseUrl, $frontierPath, $frontierUser,
     <br />
     <label for="fixed_html">Fixed HTML</label>
     <br />
-    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo $fixed_content ?></textarea>
+    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo htmlentities($fixed_content) ?></textarea>
   <?php endif; ?>
 <!-- page content -->
 </body>

--- a/fix_liferay.php
+++ b/fix_liferay.php
@@ -1,0 +1,46 @@
+<?php
+ini_set('display_errors', true);
+
+require_once __DIR__ . '/unl_migration.php';
+
+$baseUrl          = '';
+$frontierPath     = null;
+$frontierUser     = null;
+$frontierPass     = null;
+$ignoreDuplicates = null;
+$useLiferayCode   = true;
+$useLiferayTitles = false;
+
+$migration_tool = new UNL_Migration_Tool($baseUrl, $frontierPath, $frontierUser, $frontierPass, $ignoreDuplicates, $useLiferayCode, $useLiferayTitles);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Liferay main content fixer</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+  <h1>Fix Liferay main content</h1>
+  <p>This will strip out/replace old lefray DIVs and Content</p>
+  <form action="fix_liferay.php" method="post">
+    <label for="content_to_fix">The HTML content to fix</label>
+    <br />
+    <textarea id="content_to_fix" name="content" cols="100" rows="15"></textarea>
+    <br />
+    <input type="submit" />
+  </form>
+  
+  <?php 
+  if (isset($_POST['content'])):
+    $fixed_content = $migration_tool->_perform_liferay_maincontent_replacements($_POST['content']);
+    ?>
+    <br />
+    <label for="fixed_html">Fixed HTML</label>
+    <br />
+    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo $fixed_content ?></textarea>
+  <?php endif; ?>
+<!-- page content -->
+</body>
+</html>

--- a/fix_liferay.php
+++ b/fix_liferay.php
@@ -34,12 +34,18 @@ $migration_tool = new UNL_Migration_Tool($baseUrl, $frontierPath, $frontierUser,
   
   <?php 
   if (isset($_POST['content'])):
-    $fixed_content = $migration_tool->_perform_liferay_maincontent_replacements($_POST['content']);
+    $string = $_POST['content'];
+    
+    //Replace en dashes because of a bug in an older version of PHP
+    $string = str_replace('–', '&ndash;', $string);
+
+    $fixed_content = $migration_tool->_perform_liferay_maincontent_replacements($string);
     ?>
     <br />
     <label for="fixed_html">Fixed HTML</label>
     <br />
-    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo htmlentities($fixed_content) ?></textarea>
+    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo htmlentities($fixed_content, null, 'UTF-8', false) ?></textarea>
+    <textarea id="fixed_html" name="fixed_html" cols="100" rows="15" readonly="readonly"><?php echo $fixed_content ?></textarea>
   <?php endif; ?>
 <!-- page content -->
 </body>

--- a/unl_migration.php
+++ b/unl_migration.php
@@ -1558,7 +1558,7 @@ class Unl_Migration_Tool
     return "contains(concat(' ', normalize-space(@class), ' '), ' " . $class . " ')";
   }
 
-  private function _perform_liferay_maincontent_replacements($maincontent) {
+  public function _perform_liferay_maincontent_replacements($maincontent) {
     if (!$this->_useLiferayCode) {
       return FALSE;
     }
@@ -1636,6 +1636,42 @@ class Unl_Migration_Tool
     foreach ($result as $node) {
       $node->setAttribute('class', $node->getAttribute('class') . ' bp1-wdn-col-two-thirds');
     }
+    
+    //Remove classes
+    $clases_to_remove = array(
+      'portlet-column',
+      'aui-w33',
+      'portlet-column-first',
+      'portlet-dropzone',
+      'portlet-column-content',
+      'portlet-column-content-first',
+      'portlet-boundary',
+      'portlet-static',
+      'portlet-static-end',
+      'portlet-borderless',
+      'portlet-journal-content',
+      'portlet-boundary',
+      'portlet-boundary_56_',
+      'portlet-body',
+      'portlet-borderless-container',
+      'portlet-layout'
+    );
+    
+    foreach ($clases_to_remove as $class_to_remove) {
+      $result = $xpath->query("//*[" . $this->xpath_get_has_class($class_to_remove) . "]");
+
+      foreach ($result as $node) {
+        
+        $classes = explode(' ', $node->getAttribute('class'));
+        
+        while (in_array($class_to_remove, $classes)) {
+          unset($classes[array_search($class_to_remove, $classes)]);
+        }
+        
+        $node->setAttribute('class', implode(' ', $classes));
+      }
+    }
+    
 
     $nodes = $xpath->query("//div[@id='main-content']");
 

--- a/unl_migration.php
+++ b/unl_migration.php
@@ -1777,7 +1777,6 @@ class Unl_Migration_Tool
       'output-xhtml' => TRUE,
       'show-body-only' => TRUE,
       'wrap' => 0,
-      'numeric-entities' => true,
       'new-blocklevel-tags' => 'article,header,footer,section,nav,main,aside,figure,figcaption',
       'new-inline-tags'     => 'video,audio,canvas,ruby,rt,rp,track,mark,meter,time',
     );

--- a/unl_migration.php
+++ b/unl_migration.php
@@ -1777,6 +1777,7 @@ class Unl_Migration_Tool
       'output-xhtml' => TRUE,
       'show-body-only' => TRUE,
       'wrap' => 0,
+      'numeric-entities' => true,
       'new-blocklevel-tags' => 'article,header,footer,section,nav,main,aside,figure,figcaption',
       'new-inline-tags'     => 'video,audio,canvas,ruby,rt,rp,track,mark,meter,time',
     );


### PR DESCRIPTION
It was discovered that certain classes were causing problems with TinyMCE and a ton on extra DIVs were being included.  This should resolve both issues by removing extra classes/divs.

@ericras Is there any way to apply this to content that has already been imported?
